### PR TITLE
Formatting cleanups and minor fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ This is a (partial) clone of [slackin](http://rauchg.com/slackin) for [Google Ap
 It provides
 
 - A landing page you can point users to fill in their emails and receive an invite
-- A free https://<your-project>.appspot.com domain name!
+- A free SSL-secured endpoint at `https://<your-project>.appspot.com`!
 
-### Why App Engine?
+### Why Google App Engine?
 
-Most slack inviters require you to run a server 24/7 to work. However, most users will visit the app once and never come back to it!
+Most Slack inviters require you to run a server 24/7 to work. However, most users will visit the app once and never come back to it!
 
-With App Engine, you can run your slack inviter with the App Engine free tier and never worry about it again! If your community starts to recieve a lot of traffic, App Engine will automatically scale to handle the load as well.
+With App Engine, you can run your Slack inviter with the App Engine free tier and never worry about it again! If your community starts to recieve a lot of traffic, App Engine will automatically scale to handle the load as well.
 
-[Slackin](http://rauchg.com/slackin) is my favorite slack inviter, but won't run on App Engine without using [custom runtimes](https://cloud.google.com/appengine/docs/managed-vms/custom-runtimes). So SlackEngine was born!
+[Slackin](http://rauchg.com/slackin) is my favorite Slack inviter, but won't run on App Engine without using [custom runtimes](https://cloud.google.com/appengine/docs/managed-vms/custom-runtimes). So SlackEngine was born!
 
 ## How to use
 
@@ -25,20 +25,20 @@ With App Engine, you can run your slack inviter with the App Engine free tier an
 * Visit the [Google Developers Console](https://console.developers.google.com/project), and create a new project.
 * Visit [reCAPTCHA](https://www.google.com/recaptcha/admin), and register your website.
 * Install reCAPTCHA library with [Composer](https://getcomposer.org/)
-    * run ```composer install```
+    * run `composer install`
 * Edit [app.yaml](app.yaml)
-    * Replace ```<PROJECT-ID>``` with the project ID you just created
+    * Replace `<PROJECT-ID>` with the project ID you just created
 * Edit [constants.php](constants.php)
-    * Replace ```<YOUR-SUBDOMAIN>``` with your team's slack subdomain (i.e If your slack is myteam.slack.com, your subdomain is 'myteam').
-    * Replace ```<YOUR-API-TOKEN>``` with your slack API token
-      * You can find your API token at api.slack.com/web
+    * Replace `<YOUR-SUBDOMAIN>` with your team's Slack subdomain, e.g., if your Slack is `myteam.slack.com`, your subdomain is `myteam`
+    * Replace `<YOUR-API-TOKEN>` with your Slack API token
+      * You can find your API token at https://api.slack.com/web
       * Note that the user you use to generate the token must be an admin.
       * You should create a dedicated @slackin-inviter user (or similar), mark that user an admin, and use a token from that dedicated admin user.
-      * Replace ```<YOUR-reCAPTCHA-SECRET>``` with your reCAPTCHA secret
-      * Replace ```<YOUR-reCAPTCHA-SITEKEY>``` with your reCAPTCHA site key
-      * Replace ```<YOUR-NOTE>``` with a small note you want to display
+      * Replace `<YOUR-reCAPTCHA-SECRET>` with your reCAPTCHA secret
+      * Replace `<YOUR-reCAPTCHA-SITEKEY>` with your reCAPTCHA site key
+      * Replace `<YOUR-NOTE>` with a small note you want to display
 * Launch your app:
-    * Run ```appcfg.py update app.yaml .```
+    * Run `appcfg.py update app.yaml .`
 
 ### Credits
 
@@ -47,6 +47,8 @@ With App Engine, you can run your slack inviter with the App Engine free tier an
 
 ### License
 
-All code is licenced under Apache v2
+Licensed under Apache 2.0, see [`LICENSE`](LICENSE) for details.
 
-Note: This is not an official Google product.
+## Disclaimer
+
+This is not an official Google product.


### PR DESCRIPTION
* Added missing code formatting where needed, e.g., to show `<` and `>`
* Capitalize uses of "Slack"
* Convert triple-backticks to single-backticks for inline code formatting
* Link directly to the license file
* Add a disclaimer section for visibility